### PR TITLE
Fixed display of StackOperaton's options on stack:list command

### DIFF
--- a/src/Command/StackListCommand.php
+++ b/src/Command/StackListCommand.php
@@ -53,7 +53,7 @@ class StackListCommand extends BaseRokkaCliCommand
                 $data = [
                     null, null,
                     $operation->name,
-                    RokkaLibrary::formatStackOperationOptions($operation->options, true),
+                    RokkaLibrary::formatStackOperationOptions($operation->options),
                 ];
 
                 $table->addRow($data);

--- a/src/RokkaLibrary.php
+++ b/src/RokkaLibrary.php
@@ -156,24 +156,12 @@ class RokkaLibrary
      *
      * @return string
      */
-    public static function formatStackOperationOptions(array $settings, $associative = false)
+    public static function formatStackOperationOptions(array $settings)
     {
         $data = [];
 
-        if (!$associative) {
-            $fixed_settings = [];
-            foreach ($settings as $name => $value) {
-                $fixed_settings[] = array(
-                    'name' => $name,
-                    'value' => $value,
-                );
-            }
-
-            $settings = $fixed_settings;
-        }
-
-        foreach ($settings as $setting) {
-            $data[] = $setting['name'].':'.$setting['value'];
+        foreach ($settings as $name => $value) {
+            $data[] = $name.':'.$value;
         }
 
         return implode(' | ', $data);


### PR DESCRIPTION
RokkaAPI is returning an associative array for StackOperation's options:

```
"stack_operations" : [{
    "name":"resize",
    "options":{
        "width":"480",
        "height":"480"
    }
}],
```