### PR TITLE
 Improved images:copy-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file based on the
 [Keep a Changelog](http://keepachangelog.com/) Standard.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/rokka-io/rokka-client-php-cli/compare/1.7.0...master)
+## [Unreleased](https://github.com/rokka-io/rokka-client-php-cli/compare/1.8.0...master)
 
 ### Added
 ### Changed
@@ -11,6 +11,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 ### Security
+
+## [1.8.0](https://github.com/rokka-io/rokka-client-php-cli/releases/tag/1.8.0) - 2018-12-13
+
+### Changed
+- `image:copy-all` uses the new batch copy of rokka. Makes copying images much faster
 
 ## [1.7.0](https://github.com/rokka-io/rokka-client-php-cli/releases/tag/1.7.0) - 2018-10-25
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   ],
   "require": {
     "php": "^5.6 || ^7.0",
-    "rokka/client": "^1.7.0",
+    "rokka/client": "^1.9.0",
     "symfony/console" : "^2.7 || ^3.0 || ^4.0",
     "symfony/finder" : "^2.7 || ^3.0 || ^4.0",
     "symfony/config": "^2.7 || ^3.0 || ^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82ad2753dc5adb76ffb6b01a294e7224",
+    "content-hash": "ca28a7495db70ce6ba43b21f3915767e",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -431,16 +431,16 @@
         },
         {
             "name": "rokka/client",
-            "version": "1.8.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rokka-io/rokka-client-php.git",
-                "reference": "e3fb24a20a38f6269c264969d79ddf035dce5c75"
+                "reference": "c6ad2d4560d53f0c72fe074257c32e1039fab76c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rokka-io/rokka-client-php/zipball/e3fb24a20a38f6269c264969d79ddf035dce5c75",
-                "reference": "e3fb24a20a38f6269c264969d79ddf035dce5c75",
+                "url": "https://api.github.com/repos/rokka-io/rokka-client-php/zipball/c6ad2d4560d53f0c72fe074257c32e1039fab76c",
+                "reference": "c6ad2d4560d53f0c72fe074257c32e1039fab76c",
                 "shasum": ""
             },
             "require": {
@@ -489,7 +489,7 @@
                 "rokka",
                 "rokka.io"
             ],
-            "time": "2018-11-05T10:36:50+00:00"
+            "time": "2018-12-13T10:15:43+00:00"
         },
         {
             "name": "symfony/config",


### PR DESCRIPTION
uses the new `copySourceImages` from https://github.com/rokka-io/rokka-client-php/pull/61

- [x] merge of https://github.com/rokka-io/rokka-client-php/pull/61
- [x] update composer.json to use then released 1.9